### PR TITLE
Closes #2. Initial target for SWA done using Azure Portal

### DIFF
--- a/docs/BlazorClientTarget.md
+++ b/docs/BlazorClientTarget.md
@@ -1,0 +1,21 @@
+# Blazor Client Web Assembly Deployment 
+
+Initially created the MudBlazor admin dashboard sample using the following CLI command
+
+```
+dotnet new mudblazor --host wasm --name BlazorGolf -t admindashboard
+```
+
+This enabled local build. Checked in the solution.
+Created resource group in Azure for the BlazorClient app
+Created an Azure SWA app and then configured for the following:
+
+- Used current GitHub repo
+- specified blank Functions url
+- specified /src/BlazorGolfClient as the app path
+- specified /wwwroot as the output path
+- Azure SWA configured the workflow (GH Action) and kicked of a deployment. 
+
+Deploy was successful and could access app from Azure SWA endpoint.
+
+


### PR DESCRIPTION
Closes #2 and completes the initial deployment to SWA.  May change worklfow file name or may script to enable creation of new SWA in the future. 