### PR TITLE
Restrict build / deploy to WASM client path

### DIFF
--- a/.github/workflows/azure-static-web-apps-blue-coast-0041f950f.yml
+++ b/.github/workflows/azure-static-web-apps-blue-coast-0041f950f.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/BlazorGolfClient/**'
 
 jobs:
   build_and_deploy_job:


### PR DESCRIPTION
Restrict build / deploy to WASM client path so API checkins do not kick off client builds. Closes #15 